### PR TITLE
feat: macOS font theme configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Add claude folder 
+.claude/

--- a/config/.config/scripts/import-gsettings.sh
+++ b/config/.config/scripts/import-gsettings.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# usage: import-gsettings
+config="${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini"
+if [ ! -f "$config" ]; then exit 1; fi
+
+gnome_schema="org.gnome.desktop.interface"
+gtk_theme="$(grep 'gtk-theme-name' "$config" | sed 's/.*\s*=\s*//')"
+icon_theme="$(grep 'gtk-icon-theme-name' "$config" | sed 's/.*\s*=\s*//')"
+cursor_theme="$(grep 'gtk-cursor-theme-name' "$config" | sed 's/.*\s*=\s*//')"
+font_name="$(grep 'gtk-font-name' "$config" | sed 's/.*\s*=\s*//')"
+gsettings set "$gnome_schema" gtk-theme "$gtk_theme"
+gsettings set "$gnome_schema" icon-theme "$icon_theme"
+gsettings set "$gnome_schema" cursor-theme "$cursor_theme"
+gsettings set "$gnome_schema" font-name "$font_name"

--- a/ghostty/.config/ghostty/config
+++ b/ghostty/.config/ghostty/config
@@ -17,10 +17,14 @@
 theme = tokyonight_night
 
 # Define the font family and size for the interface.
-# '0xProto Nerd Font' is a monospaced font with additional glyphs for developers.
+# '.SF NS Mono' is the macOS system monospaced font.
 # The font size is set to 14 pixels.
-font-family = 0xProto Nerd Font
+font-family = .SF NS Mono
 font-size = 14
+
+# Enable font features for better rendering
+font-feature = +calt
+font-feature = +liga
 
 # Set the horizontal padding for the window.
 # The values represent the left and right padding in pixels.

--- a/gtk-3.0/.config/gtk-3.0/settings.ini
+++ b/gtk-3.0/.config/gtk-3.0/settings.ini
@@ -1,0 +1,23 @@
+[Settings]
+# --- Themes ---
+gtk-theme-name=Tokyonight-Dark
+gtk-icon-theme-name=Tokyonight-Moon
+
+# --- Fonts ---
+gtk-font-name=SF Pro Text 10
+gtk-monospaced-font-name=SF Mono 11
+
+# --- Other Settings ---
+gtk-cursor-theme-name=default
+gtk-cursor-theme-size=24
+gtk-toolbar-style=GTK_TOOLBAR_ICONS
+gtk-toolbar-icon-size=GTK_ICON_SIZE_LARGE_TOOLBAR
+gtk-button-images=0
+gtk-menu-images=0
+gtk-enable-event-sounds=1
+gtk-enable-input-feedback-sounds=0
+gtk-xft-antialias=1
+gtk-xft-hinting=1
+gtk-xft-hintstyle=hintfull
+gtk-xft-rgba=rgb
+gtk-application-prefer-dark-theme=1

--- a/hyprland/.config/hypr/conf/autostart.conf
+++ b/hyprland/.config/hypr/conf/autostart.conf
@@ -7,6 +7,9 @@
 # Setup XDG for screen sharing and start waypaper and waybar
 exec-once = ~/.config/hypr/scripts/xdg.sh
 
+# Import GSettings
+exec = sh ~/.config/scripts/import-gsettings.sh
+
 # Launch Waybar
 exec-once = sh ~/.config/waybar/scripts/launch.sh
 


### PR DESCRIPTION
## Summary
- Configure ghostty to use macOS system fonts (.SF NS Mono)
- Add GTK 3.0 settings with SF Pro Text and SF Mono fonts
- Enable font ligatures and contextual alternates for improved rendering
- Add import-gsettings.sh script for GTK theme synchronization

## Changes
- **Ghostty**: Updated from 0xProto Nerd Font to `.SF NS Mono` with ligatures enabled
- **GTK 3.0**: Configured SF Pro Text (UI) and SF Mono (monospace) fonts
- **Scripts**: Added gsettings import script for theme consistency
- **Hyprland**: Integrated gsettings import on startup

## Test plan
- [x] Verified `.SF NS Mono` font loads correctly in ghostty
- [x] Confirmed font features (ligatures, contextual alternates) are active
- [x] Tested ghostty CLI commands work despite GTK warnings
- [x] Validated configuration with `ghostty +validate-config`
