### PR TITLE
fix(zsh): strip wal background OSC to keep terminal transparency

### DIFF
--- a/zshrc/.zshrc
+++ b/zshrc/.zshrc
@@ -45,8 +45,12 @@ export PATH="${PATH}:${HOME}/.local/bin/"
 export FLYCTL_INSTALL="/home/qdrtech/.fly"
 export PATH="$FLYCTL_INSTALL/bin:$PATH"
 
-# Import colorscheme from 'wal'
-(cat $HOME/.cache/wal/sequences)
+# Import colorscheme from 'wal', minus the background/highlight-background
+# sequences (OSC 11/17/19/708). Those set an opaque background at runtime and
+# override ghostty's background-opacity, killing terminal transparency.
+if [[ -f $HOME/.cache/wal/sequences ]]; then
+  sed -E 's/\x1b\](11|17|19|708);[^\x1b]*\x1b\\//g' "$HOME/.cache/wal/sequences"
+fi
 
 # pnpm
 export PNPM_HOME="/home/qdrtech/.local/share/pnpm"


### PR DESCRIPTION
## Problem

`.zshrc` cat'd `~/.cache/wal/sequences` verbatim. That file contains `OSC 11;#0A0907` (plus 17/19/708), which sets the terminal background at runtime and overrides ghostty's `background-opacity` — windows rendered flat opaque `#0A0907`.

Looked like a tmux problem because the long-lived tmux window showed it most. tmux was not involved: pixel A/B of plain shell vs tmux in the same window was identical at both 0.8 and 0.2 opacity.

## Fix

Filter OSC 11/17/19/708 out of the sequences before sourcing. Palette (OSC 4), foreground (10) and cursor (12/13) still load.

## Verification

Captured raw output of `zsh -i`:
- OSC 11/17/19/708: none emitted (was `]11;#0A0907`)
- 18 `OSC 4` palette entries kept, plus OSC 10/12/13
- `zsh -n` clean
- Screen probe of a fresh ghostty + zsh + tmux no longer reads flat `#0A0907`

Existing shells keep the old background until restarted.