### PR TITLE
feat(hypridle): disable idle suspend to keep machine always on

### DIFF
--- a/hyprland/.config/hypr/hypridle.conf
+++ b/hyprland/.config/hypr/hypridle.conf
@@ -38,10 +38,10 @@ listener {
     on-resume = hyprctl dispatch dpms on
 }
 
-# Suspend
-listener {
-    # SUSPEND TIMEOUT
-    timeout = 1800
-    #SUSPEND ONTIMEOUT
-    on-timeout = systemctl suspend
-}
+# Suspend (disabled — machine must not suspend/hibernate on idle)
+# listener {
+#     # SUSPEND TIMEOUT
+#     timeout = 1800
+#     #SUSPEND ONTIMEOUT
+#     on-timeout = systemctl suspend
+# }


### PR DESCRIPTION
Comments out the hypridle suspend listener (30-min idle -> systemctl suspend) so the machine stays powered on for long-running agents.

Screen lock (10 min) and DPMS off (11 min) listeners unchanged. logind already ignores lid/idle/suspend-key, so hypridle was the only suspend trigger.