### PR TITLE
fix: remove hardcoded home directory paths from tracked files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,8 @@ stow -t "$HOME" hyprland waybar rofi ghostty swaync themes config \
 `stow` defaults its target to the parent of the repo directory. Cloning to
 `~/dotfiles` makes the default target `$HOME`; `-t "$HOME"` states it
 explicitly and works from any clone location, because stow computes its
-symlink targets relative to wherever the repo actually is.
-
-The clone path still matters for one thing: `tmux/.tmux.conf:16` hardcodes
-`bind r source-file ~/dotfiles/tmux/.tmux.conf`.
+symlink targets relative to wherever the repo actually is. Nothing in the repo
+assumes a particular clone path.
 
 ## Theming
 
@@ -84,16 +82,6 @@ will break.
 
 This config is tied to one machine. Specifically:
 
-- **Hardcoded home directory.** `/home/qdrtech` is written literally in
-  `zshrc/.zshrc` (lines 14, 32, 45, 56, 79),
-  `rofi/.config/rofi/config.rasi:9` and
-  `themes/.config/themes/default/rofi.rasi:2`. Another user's shell, launcher
-  and theme will not work unmodified. That is the full list outside the `nvim`
-  submodule; re-check with `git grep -n /home/qdrtech`, which does not read the
-  symlink targets below.
-- **Committed absolute-path symlinks.** `rofi/.config/rofi/theme.rasi` and
-  `swaync/.config/swaync/style.css` are symlinks whose targets start with
-  `/home/qdrtech`. They are dangling for anyone else.
 - **Monitor-specific.** `hyprland/.config/hypr/conf/monitors.conf` and
   `workspace.conf` name `DP-1` and `DP-2` with fixed modes and workspace
   assignments. `hyprland/.config/hypr/hyprpaper.conf` and `hyprlock.conf` also

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,17 +9,15 @@ git clone --recurse-submodules <this-repo> ~/dotfiles
 cd ~/dotfiles
 ```
 
-Clone to `~/dotfiles`. Stow is not the reason: it creates the `~/.config`
-symlinks itself at stow time and computes each relative target from wherever
-you cloned, so stow's own links work from any location. The clone path matters
-for exactly one thing — `tmux/.tmux.conf:16` hardcodes
-`bind r source-file ~/dotfiles/tmux/.tmux.conf`, so the tmux reload binding only
-works from a clone at `~/dotfiles`.
+`~/dotfiles` is a convention, not a requirement. Stow creates the `~/.config`
+symlinks at stow time and computes each relative target from wherever you
+cloned, and nothing in the repo assumes a particular clone path.
 
-Two symlinks *are* committed, and both have **absolute** targets:
-`rofi/.config/rofi/theme.rasi` and `swaync/.config/swaync/style.css` point at
-`/home/qdrtech/.config/themes/default/`. Those are unaffected by where you clone
-and dangle for any other user. See [packages.md](packages.md).
+Two symlinks *are* committed — `rofi/.config/rofi/theme.rasi` and
+`swaync/.config/swaync/style.css`. Their targets are relative to the repo
+(`../../../themes/.config/themes/default/`), so they resolve from any clone
+path for any user, whether or not stow folds the directory. See
+[packages.md](packages.md).
 
 The `nvim` package is a git submodule pointing at
 `git@github.com:qdrtech/xghost-config` over SSH. Without access to that repo the
@@ -188,9 +186,9 @@ These are real, verified gaps. Fix or ignore, but do not expect them to work.
     `@bg`, `@surface` and `@text` — used at lines 9, 10, 19, 24 and 25 — are
     undefined, so the bar comes up unstyled.
   - Rofi is the exception: `rofi/.config/rofi/config.rasi:9` points `@theme` at
-    the absolute path `/home/qdrtech/.config/rofi/generated-theme.rasi`, and
-    `generated-theme.rasi` *is* committed, so it resolves for the user
-    `qdrtech` and fails for anyone else.
+    `generated-theme.rasi`, which rofi resolves against the directory of the
+    including file, and `generated-theme.rasi` *is* committed — so the launcher
+    comes up themed with no generation step.
 
   The only thing that writes these files is `scripts/theme-switch.sh`
   (`scripts/theme-switch.sh:15-18`), and it is broken — see
@@ -205,10 +203,13 @@ These are real, verified gaps. Fix or ignore, but do not expect them to work.
   `wofi -c ~/.config/wofi/waybar -s ~/.config/wofi/style-waybar.css`. The `wofi`
   package only ships `wofi/.config/wofi/style.css`.
 - **Theming does not apply cleanly.** See [theme-switching.md](theme-switching.md).
-- **Hardcoded paths.** `/home/qdrtech` appears literally in `zshrc/.zshrc`
-  (lines 14, 32, 45, 56, 79), `rofi/.config/rofi/config.rasi:9` and
-  `themes/.config/themes/default/rofi.rasi:2`, and it is the target of both
-  committed symlinks (`rofi/.config/rofi/theme.rasi`,
-  `swaync/.config/swaync/style.css`). That is the full list outside the `nvim`
-  submodule. Re-check with `git grep -n /home/qdrtech` — which does not read
-  symlink targets — and fix before using on another account.
+- **`themes/.config/themes/default/rofi.rasi` does not parse.** Rofi rejects the
+  file itself (`rofi -no-config -theme <file> -dump-theme` warns "Failed to
+  parse theme"), and so does the `theme-colors.rasi` it imports, which uses a
+  top-level `@name: value;` form rofi no longer accepts. Nothing in the live
+  launcher path loads either file — `config.rasi` uses `generated-theme.rasi` —
+  so this only matters if the theme switcher is revived.
+
+No absolute path carrying a username is left in the tree, including symlink
+targets. Re-check with `git grep -n /home/` plus
+`git ls-tree -r HEAD | grep 120000` — `git grep` does not read symlink targets.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -211,5 +211,12 @@ These are real, verified gaps. Fix or ignore, but do not expect them to work.
   so this only matters if the theme switcher is revived.
 
 No absolute path carrying a username is left in the tree, including symlink
-targets. Re-check with `git grep -n /home/` plus
-`git ls-tree -r HEAD | grep 120000` — `git grep` does not read symlink targets.
+targets, with one exception: `themes/.config/themes/README.md:210` still holds a
+`/home/username/...` placeholder inside a waybar config example. That file
+documents the superseded file-first theme switcher and is stale throughout, so
+it was left untouched; it is tracked under issue #43.
+
+Re-check with `git grep -n /home/` — it returns that placeholder and this
+document's own mentions of the pattern, nothing else — plus
+`git ls-tree -r HEAD | grep 120000`, because `git grep` does not read symlink
+targets.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -129,8 +129,8 @@ commit a submodule pointer change unless you mean to.
 
 | File | What it does |
 | --- | --- |
-| `config.rasi` | Launcher config and full widget styling. Line 9 loads the generated theme with an **absolute** path: `@theme "/home/qdrtech/.config/rofi/generated-theme.rasi"`. |
-| `theme.rasi` | A committed **symlink** to `/home/qdrtech/.config/themes/default/rofi.rasi`. Left over from the older theme switcher; `config.rasi` no longer references it. Dangling on any other machine. |
+| `config.rasi` | Launcher config and full widget styling. Line 9 loads the generated theme with `@theme "generated-theme.rasi"`; rofi resolves an `@import`/`@theme` filename against the directory of the including file. |
+| `theme.rasi` | A committed **symlink** to `../../../themes/.config/themes/default/rofi.rasi`, i.e. into the `themes` package of this repo. Left over from the older theme switcher; `config.rasi` no longer references it. |
 | `theme-colors.rasi`, `generated-theme.rasi` | **Generated** by `scripts/theme-switch.sh`, committed for the same folded-symlink reason as Ghostty's `theme.conf`. |
 
 `config.rasi` also uses `@color11` and `@background`, which come from pywal
@@ -145,7 +145,7 @@ output rather than from the theme switcher.
 | File | What it does |
 | --- | --- |
 | `config.json` | SwayNC behaviour. |
-| `style.css` | A committed **symlink** to `/home/qdrtech/.config/themes/default/swaync.css`, written by the older theme switcher. Dangling on any other machine. |
+| `style.css` | A committed **symlink** to `../../../themes/.config/themes/default/swaync.css`, i.e. into the `themes` package of this repo. Written by the older theme switcher, and still what swaync loads. |
 | `refresh.sh` | `pkill swaync; swaync`. |
 
 Waybar's `custom/notification` module toggles the panel via `swaync-client -t -sw`.
@@ -183,7 +183,8 @@ historical; it contradicts `docs/theme-switching.md`.
 Prefix remapped to `C-a`. `|` and `-` split. `M-h/j/k/l` pane navigation. Mouse
 on, `escape-time 0`, windows and panes indexed from 1. Default shell hardcoded to
 `/usr/bin/zsh`. Plugins via tpm: `tmux-resurrect` and `tmux-continuum` with
-`@continuum-restore on`. The reload binding hardcodes `~/dotfiles/tmux/.tmux.conf`.
+`@continuum-restore on`. The reload binding sources `~/.tmux.conf`, the stowed
+path, so it does not depend on where the repo is cloned.
 
 tpm itself is not vendored — clone it to `~/.tmux/plugins/tpm`.
 
@@ -266,4 +267,4 @@ Aliases: `gitprune`, `dle`, `ts` (theme switch — currently points at
 `..` through `.........`.
 
 `PATH` additions: `~/.config/scripts`, `~/.local/bin`, bun, pnpm, flyctl,
-opencode. `/home/qdrtech` is written literally on lines 14, 32, 45, 56 and 79.
+opencode. All of them go through `$HOME`; no home directory is hardcoded.

--- a/docs/theme-switching.md
+++ b/docs/theme-switching.md
@@ -82,7 +82,7 @@ SUCCESS="#a6e3a1"
    the reference machine hold a dark macOS-ish palette (`#0f1115`, `#0a84ff`)
    that is not derivable from any `colors.conf` in this repo. The source palette
    could not be located: `~/.config/themes/current` points at
-   `/home/qdrtech/dotfiles/themes/macos-dark`, and that path does not exist (the
+   `<clone>/themes/macos-dark`, and that path does not exist (the
    committed theme lives at `themes/.config/themes/macos-dark`). Running `set`
    today replaces those colours with the Catppuccin fallback.
 
@@ -139,10 +139,11 @@ component symlinks or copies the theme's own file:
 
 These exist because both switchers have been run at different times:
 
-- `~/.config/themes/current -> /home/qdrtech/dotfiles/themes/macos-dark` — dangling.
+- `~/.config/themes/current -> <clone>/themes/macos-dark` — dangling.
 - `~/.config/themes/colors.conf` — dangling, follows `current`.
 - `~/.config/rofi/theme.rasi` and `~/.config/swaync/style.css` — committed
-  symlinks with absolute `/home/qdrtech` targets, left by the file-first switcher.
+  symlinks left by the file-first switcher. Their targets are now relative to
+  the repo, so they resolve rather than dangle, but nothing regenerates them.
 - `~/.config/hypr/theme.conf` — a stray copy at the `hypr` root rather than in
   `conf/`. Nothing sources it; `hyprland/.config/hypr/hyprland.conf:41` sources
   `conf/theme.conf`.

--- a/docs/theme-switching.md
+++ b/docs/theme-switching.md
@@ -134,6 +134,14 @@ component symlinks or copies the theme's own file:
    step logs a warning and skips.
 5. `themes/.config/themes/README.md` documents this switcher. It contradicts this
    file wherever the two disagree; this file is the accurate one.
+6. **It reintroduces absolute symlink targets.** `THEMES_DIR` (`:14`),
+   `ROFI_THEME` (`:22`) and `SWAYNC_STYLE` (`:23`) are built from `$HOME`, so the
+   `ln -sf` calls at `:233` and `:251` write `$HOME/.config/themes/<theme>/...`
+   over `rofi/.config/rofi/theme.rasi` and `swaync/.config/swaync/style.css`.
+   Under folded stow both destinations land in the repo, so one run replaces
+   those two committed symlinks — made repo-relative so they resolve for any
+   user — with absolute `/home/<user>/...` targets and leaves the tree dirty.
+   This is one alias away: `ts` (`zshrc/.zshrc:21`).
 
 ## Leftovers on the reference machine
 

--- a/rofi/.config/rofi/config.rasi
+++ b/rofi/.config/rofi/config.rasi
@@ -6,7 +6,7 @@ configuration {
     drun-display-format: "{name}";
 }
 
-@theme "/home/qdrtech/.config/rofi/generated-theme.rasi"
+@theme "generated-theme.rasi"
 
 // Main //
 window {

--- a/rofi/.config/rofi/theme.rasi
+++ b/rofi/.config/rofi/theme.rasi
@@ -1,1 +1,1 @@
-/home/qdrtech/.config/themes/default/rofi.rasi
+../../../themes/.config/themes/default/rofi.rasi

--- a/swaync/.config/swaync/style.css
+++ b/swaync/.config/swaync/style.css
@@ -1,1 +1,1 @@
-/home/qdrtech/.config/themes/default/swaync.css
+../../../themes/.config/themes/default/swaync.css

--- a/themes/.config/themes/default/rofi.rasi
+++ b/themes/.config/themes/default/rofi.rasi
@@ -1,5 +1,5 @@
 /* Palette-driven Rofi theme */
-@import "/home/qdrtech/.config/rofi/theme-colors.rasi";
+@import "~/.config/rofi/theme-colors.rasi";
 
 * {
     background-color: @bg;

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -13,7 +13,7 @@ set -g @continuum-restore 'on'
 # Configuration management.
 
 	# Reload configuration file.
-	bind r source-file ~/dotfiles/tmux/.tmux.conf \; display "tmux: reloaded"
+	bind r source-file ~/.tmux.conf \; display "tmux: reloaded"
 
 # Shell management
 	# Use zsh as default Shell

--- a/wal/.config/wal/colorschemes/dark/ywal16.json
+++ b/wal/.config/wal/colorschemes/dark/ywal16.json
@@ -1,5 +1,5 @@
 {
-  "wallpaper": "/home/eli/wallpapers/pywallpaper.jpg",
+  "wallpaper": "None",
   "alpha": "100",
   "special": {
     "background": "#001E23",

--- a/zshrc/.zshrc
+++ b/zshrc/.zshrc
@@ -11,7 +11,7 @@ sh ~/.config/scripts/term-startup.sh
 
 # End of lines configured by zsh-newuser-install
 # The following lines were added by compinstall
-zstyle :compinstall filename '/home/qdrtech/.zshrc'
+zstyle :compinstall filename "$HOME/.zshrc"
 
 alias ls='ls --color=auto'
 alias grep='grep --color=auto'
@@ -29,7 +29,7 @@ source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh
 eval "$(starship init zsh)"
 
 # bun completions
-[ -s "/home/qdrtech/.bun/_bun" ] && source "/home/qdrtech/.bun/_bun"
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
 
 # bun
 export BUN_INSTALL="$HOME/.bun"
@@ -42,7 +42,7 @@ export FZF_DEFAULT_COMMAND='fd'
 export PATH=$PATH:$HOME/.config/scripts
 
 export PATH="${PATH}:${HOME}/.local/bin/"
-export FLYCTL_INSTALL="/home/qdrtech/.fly"
+export FLYCTL_INSTALL="$HOME/.fly"
 export PATH="$FLYCTL_INSTALL/bin:$PATH"
 
 # Import colorscheme from 'wal', minus the background/highlight-background
@@ -53,7 +53,7 @@ if [[ -f $HOME/.cache/wal/sequences ]]; then
 fi
 
 # pnpm
-export PNPM_HOME="/home/qdrtech/.local/share/pnpm"
+export PNPM_HOME="$HOME/.local/share/pnpm"
 case ":$PATH:" in
   *":$PNPM_HOME:"*) ;;
   *) export PATH="$PNPM_HOME:$PATH" ;;
@@ -76,4 +76,4 @@ alias .........="cd ../../../../../../../.."
 
 
 # opencode
-export PATH=/home/qdrtech/.opencode/bin:$PATH
+export PATH="$HOME/.opencode/bin:$PATH"


### PR DESCRIPTION
Removes every absolute home-directory path from tracked files, symlink targets included.

**Refs #49** — deliberately not `Closes`. Criterion 3 of that issue ("a decision is recorded on the work-specific script and the SSH submodule URL") is still open; the trade-offs are reported on #49 but the calls have not been made.

## Changes

- `rofi/.config/rofi/config.rasi` — `@theme "generated-theme.rasi"` (was an absolute path)
- `themes/.config/themes/default/rofi.rasi` — `@import "~/.config/rofi/theme-colors.rasi"`
- `rofi/.config/rofi/theme.rasi` and `swaync/.config/swaync/style.css` — committed symlinks retargeted to `../../../themes/.config/themes/default/...` (were absolute, mode 120000, dangling for any other user)
- `zshrc/.zshrc` — 5 sites now use `$HOME`; line 14 was single-quoted and is now double-quoted so it expands
- `tmux/.tmux.conf:16` — `source-file ~/.tmux.conf`, removing the forced `~/dotfiles` clone location
- `wal/.config/wal/colorschemes/dark/ywal16.json` — `"wallpaper": "None"`; it held `/home/eli/...`. pywal's own `theme.py:105` uses the same value when the key is absent
- `README.md`, `docs/{installation,packages,theme-switching}.md` — text matched to the fixed tree, since they asserted the now-fixed limitations as live

## Rofi behaviour was verified, not assumed

The brief flagged that `.rasi` files may not expand `~` or relative paths. `man 5 rofi-theme:1538` states that on `@import`/`@theme` rofi "looks in the directory of the file that tried to include it", and `:1535-1536` that absolute paths include "expansion of `~`". Both confirmed by probe:

```
=== global * block from edited config (expect palette from generated-theme.rasi) ===
    background-color: rgba ( 15, 17, 21, 100 % );
    text-color:       rgba ( 232, 232, 237, 100 % );
=== differential: same config but @theme pointing at a missing file ===
                      (empty)
=== B1: tilde @import (expect 600px) ===  13:    width:  600px ;
=== B2: control, no import ===            0
```

Correction: resolution is **lexical**, not realpath — rofi resolves against the directory of the config file *as located*, not its symlink target. That is better than realpath resolution here: after `theme-switch.sh`'s `write_atomic` does `mv tmp dest`, the stow symlink is replaced by a real generated file, and lexical resolution reads that fresh file. Realpath resolution would silently serve the stale committed copy. Do not "optimize" this back to an absolute path.

## Verification

Symlinks proved in three layouts — folded stow, unfolded stow from a different clone path, and a fresh `git clone` stowed into a clean `HOME`:

```
=== fresh clone, stowed into a clean fake HOME ===
stow ok
.config/rofi/theme.rasi   -> .../fresh/themes/.config/themes/default/rofi.rasi  [readable: yes]
.config/swaync/style.css  -> .../fresh/themes/.config/themes/default/swaync.css [readable: yes]
rofi -dump-theme: background-color: rgba ( 15, 17, 21, 100 % )

=== zsh -n zshrc/.zshrc === OK exit=0
=== python3 json.load ywal16.json === json OK, wallpaper = 'None'   (the string, which is pywal's own sentinel per theme.py:105 — not JSON null)
=== git diff --name-only main..HEAD -- nvim === (empty)
```

`git grep -n "/home/"` now returns only two hits, both intentional: `docs/installation.md:214` (the re-check command itself) and `themes/.config/themes/README.md:210` (a `/home/username/...` placeholder in a doc example for the old switcher — left alone because it could not be verified that waybar expands `~` in its `style` key, and shipping unverified advice is worse than leaving a placeholder).

## Deliberately not changed

Non-path personalization: `THEME_AUTHOR="qdrtech"`, `figlet qdrtech`, GitHub URLs, and `waybar/scripts/launch.sh:9` (`if [[ $USER = "qdrtech" ]]` — harmless; the else branch runs plain `waybar` against the same default config).

The three decision items from #49 are reported on that issue rather than actioned here: the `.gitmodules` SSH URL, `docker-login-ecr.sh`, and the `DP-1`/`DP-2` monitor config.

## Pre-existing bug found, not caused by this PR

`themes/.config/themes/default/rofi.rasi` does not parse in rofi 2.0 even with the `@import` line removed, and `rofi/.config/rofi/theme-colors.rasi` fails too — its top-level `@bg: #0f1115;` form is no longer accepted. Confirmed identical at `HEAD` before the edit. Recorded in `docs/installation.md`; it belongs to #43.


