### PR TITLE
fix(hyprland): drop the dead xdg.sh autostart entry

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -121,11 +121,14 @@ stow package at all. The one exception is the per-package file tables in
 
 **Screen sharing needs `xdg-desktop-portal-hyprland`, and nothing in this repo.**
 Nothing here sets up XDG desktop portals, and nothing here needs to: the
-Hyprland binary exports the session environment itself, with a built-in
-`systemctl --user import-environment DISPLAY WAYLAND_DISPLAY
-HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH
-XDG_DATA_DIRS && … dbus-update-activation-environment --systemd …` (visible in
-`strings /usr/bin/Hyprland`). What screen sharing does require is a portal
+Hyprland binary exports the session environment itself, with a built-in call
+that is visible in `strings /usr/bin/Hyprland`:
+
+```
+systemctl --user import-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS && … dbus-update-activation-environment --systemd …
+```
+
+What screen sharing does require is a portal
 _backend_: `xdg-desktop-portal-hyprland`, alongside `xdg-desktop-portal`
 itself. Without it there is no `hyprland.portal` in
 `/usr/share/xdg-desktop-portal/portals/` and `org.freedesktop.portal.ScreenCast`
@@ -135,8 +138,11 @@ configuration from this repo: `/usr/share/xdg-desktop-portal/hyprland-portals.co
 shipped by the `hyprland` package, already declares `[preferred]
 default=hyprland;gtk`. Installing the backend mid-session is not enough on its
 own, since `xdg-desktop-portal` only scans for backends at startup; log out and
-back in, or `systemctl --user restart xdg-desktop-portal
-xdg-desktop-portal-hyprland`.
+back in, or restart the portal services:
+
+```sh
+systemctl --user restart xdg-desktop-portal xdg-desktop-portal-hyprland
+```
 
 ### Required by Waybar modules
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -135,10 +135,10 @@ itself. Without it there is no `hyprland.portal` in
 never appears on the bus — `gtk.portal` does not implement ScreenCast at all,
 and `gnome.portal` does but is gated `UseIn=gnome`. The backend needs no
 configuration from this repo: `/usr/share/xdg-desktop-portal/hyprland-portals.conf`,
-shipped by the `hyprland` package, already declares `[preferred]
-default=hyprland;gtk`. Installing the backend mid-session is not enough on its
-own, since `xdg-desktop-portal` only scans for backends at startup; log out and
-back in, or restart the portal services:
+shipped by the `hyprland` package, already declares
+`[preferred] default=hyprland;gtk`. Installing the backend mid-session is not
+enough on its own, since `xdg-desktop-portal` only scans for backends at
+startup; log out and back in, or restart the portal services:
 
 ```sh
 systemctl --user restart xdg-desktop-portal xdg-desktop-portal-hyprland

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -185,7 +185,7 @@ or the setting silently falls back.
 
 ## 5. Known gaps after stowing
 
-These are real, verified gaps. Fix or ignore, but do not expect them to work.
+This is a real, verified gap. Fix or ignore, but do not expect it to work.
 
 - **The generated colour files do not exist until you run the theme switcher.**
   None of them are tracked. Run this once, immediately after stowing:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,6 +118,7 @@ stow package at all. The one exception is the per-package file tables in
 | `playerctl`                         | `playerctl`              | `hyprland/.config/hypr/conf/keybinding.conf:73-76`                                                                            |
 | `gsettings`                         | `glib2`                  | `config/.config/scripts/import-gsettings.sh`                                                                                  |
 | `killall`                           | `psmisc`                 | `waybar/.config/waybar/scripts/launch.sh`, `hyprland/.config/hypr/scripts/hyprpaper.sh`                                       |
+| screen sharing (portal backend)     | `xdg-desktop-portal-hyprland` | nothing in this repo; required by the desktop for screen sharing, alongside `xdg-desktop-portal`                              |
 
 **Screen sharing needs `xdg-desktop-portal-hyprland`, and nothing in this repo.**
 Nothing here sets up XDG desktop portals, and nothing here needs to: the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -103,21 +103,40 @@ stow package at all. The one exception is the per-package file tables in
 | `Hyprland`, `hyprctl`               | `hyprland`               | the whole `hyprland` package                                                                                                  |
 | `hypridle`                          | `hypridle`               | `hyprland/.config/hypr/conf/autostart.conf`, `hyprland/.config/hypr/hypridle.conf`                                            |
 | `hyprlock`                          | `hyprlock`               | `hyprland/.config/hypr/conf/keybinding.conf:20`, `hyprland/.config/hypr/hyprlock.conf`, `hyprland/.config/hypr/hypridle.conf` |
-| `hyprpaper`                         | `hyprpaper`              | `hyprland/.config/hypr/conf/autostart.conf:23`, `hyprland/.config/hypr/scripts/hyprpaper.sh`                                  |
-| `hyprshade`                         | `hyprshade` (AUR)        | `hyprland/.config/hypr/conf/autostart.conf:20`, `hyprshade/.config/hyprshade/config.toml`                                     |
+| `hyprpaper`                         | `hyprpaper`              | `hyprland/.config/hypr/conf/autostart.conf:20`, `hyprland/.config/hypr/scripts/hyprpaper.sh`                                  |
+| `hyprshade`                         | `hyprshade` (AUR)        | `hyprland/.config/hypr/conf/autostart.conf:17`, `hyprshade/.config/hyprshade/config.toml`                                     |
 | `hyprshot`                          | `hyprshot` (AUR)         | `hyprland/.config/hypr/conf/keybinding.conf:18-19`                                                                            |
-| `waybar`                            | `waybar`                 | `hyprland/.config/hypr/conf/autostart.conf:14`, `waybar/.config/waybar/scripts/*`                                             |
+| `waybar`                            | `waybar`                 | `hyprland/.config/hypr/conf/autostart.conf:11`, `waybar/.config/waybar/scripts/*`                                             |
 | `rofi`                              | `rofi` / `rofi-wayland`  | `hyprland/.config/hypr/hyprland.conf:17` (`$menu = rofi -show drun`)                                                          |
 | `ghostty`                           | `ghostty`                | `hyprland/.config/hypr/hyprland.conf:15` (`$terminal`)                                                                        |
 | `nautilus`                          | `nautilus`               | `hyprland/.config/hypr/hyprland.conf:16` (`$fileManager`)                                                                     |
 | `swaync`, `swaync-client`           | `swaync`                 | `waybar/.config/waybar/config` notification module, `swaync/` package                                                         |
-| `nm-applet`                         | `network-manager-applet` | `hyprland/.config/hypr/conf/autostart.conf:23`                                                                                |
-| `blueman-applet`, `blueman-manager` | `blueman`                | `hyprland/.config/hypr/conf/autostart.conf:23`, `waybar/.config/waybar/config`                                                |
+| `nm-applet`                         | `network-manager-applet` | `hyprland/.config/hypr/conf/autostart.conf:20`                                                                                |
+| `blueman-applet`, `blueman-manager` | `blueman`                | `hyprland/.config/hypr/conf/autostart.conf:20`, `waybar/.config/waybar/config`                                                |
 | `wpctl`                             | `wireplumber`            | `hyprland/.config/hypr/conf/keybinding.conf:65-68` (volume keys)                                                              |
 | `brightnessctl`                     | `brightnessctl`          | `hyprland/.config/hypr/conf/keybinding.conf:69-70`                                                                            |
 | `playerctl`                         | `playerctl`              | `hyprland/.config/hypr/conf/keybinding.conf:73-76`                                                                            |
 | `gsettings`                         | `glib2`                  | `config/.config/scripts/import-gsettings.sh`                                                                                  |
 | `killall`                           | `psmisc`                 | `waybar/.config/waybar/scripts/launch.sh`, `hyprland/.config/hypr/scripts/hyprpaper.sh`                                       |
+
+**Screen sharing needs `xdg-desktop-portal-hyprland`, and nothing in this repo.**
+Nothing here sets up XDG desktop portals, and nothing here needs to: the
+Hyprland binary exports the session environment itself, with a built-in
+`systemctl --user import-environment DISPLAY WAYLAND_DISPLAY
+HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH
+XDG_DATA_DIRS && … dbus-update-activation-environment --systemd …` (visible in
+`strings /usr/bin/Hyprland`). What screen sharing does require is a portal
+_backend_: `xdg-desktop-portal-hyprland`, alongside `xdg-desktop-portal`
+itself. Without it there is no `hyprland.portal` in
+`/usr/share/xdg-desktop-portal/portals/` and `org.freedesktop.portal.ScreenCast`
+never appears on the bus — `gtk.portal` does not implement ScreenCast at all,
+and `gnome.portal` does but is gated `UseIn=gnome`. The backend needs no
+configuration from this repo: `/usr/share/xdg-desktop-portal/hyprland-portals.conf`,
+shipped by the `hyprland` package, already declares `[preferred]
+default=hyprland;gtk`. Installing the backend mid-session is not enough on its
+own, since `xdg-desktop-portal` only scans for backends at startup; log out and
+back in, or `systemctl --user restart xdg-desktop-portal
+xdg-desktop-portal-hyprland`.
 
 ### Required by Waybar modules
 
@@ -195,11 +214,6 @@ These are real, verified gaps. Fix or ignore, but do not expect them to work.
   - `ghostty/.config/ghostty/config` does `config-file = ?theme.conf`. The `?`
     marks the include optional, so with the file absent Ghostty starts on its
     built-in colours rather than failing; `ghostty +validate-config` exits 0.
-
-- **`~/.config/hypr/scripts/xdg.sh` does not exist.**
-  `hyprland/.config/hypr/conf/autostart.conf:8` runs it on every login. It was
-  never committed. Its stated job was XDG desktop portal setup for screen
-  sharing.
 
 No absolute path carrying a username is left in the tree, including symlink
 targets.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -23,7 +23,7 @@ Shared helpers that are not tied to one program.
 | File                                                                     | What it does                                                                                                                                                                         |
 | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `scripts/term-startup.sh`                                                | Runs `figlet qdrtech` then `fastfetch`. Called from `zshrc/.zshrc:10`.                                                                                                               |
-| `scripts/import-gsettings.sh`                                            | Reads `gtk-3.0/settings.ini` and pushes theme/icon/cursor/font into `org.gnome.desktop.interface` via `gsettings`. Run on login from `hyprland/.config/hypr/conf/autostart.conf:11`. |
+| `scripts/import-gsettings.sh`                                            | Reads `gtk-3.0/settings.ini` and pushes theme/icon/cursor/font into `org.gnome.desktop.interface` via `gsettings`. Run on login from `hyprland/.config/hypr/conf/autostart.conf:8`.  |
 | `scripts/git-prune.sh`                                                   | `git fetch --prune`, then interactively deletes local branches whose upstream is gone. Aliased to `gitprune`.                                                                        |
 | `scripts/docker-login-ecr.sh`                                            | Work-specific AWS ECR login. Aliased to `dle`. Not generally useful.                                                                                                                 |
 | `scripts/wal`                                                            | A vendored copy of the pywal shell script (`wal`) by Dylan Araps. Requires ImageMagick's `convert`.                                                                                  |
@@ -102,7 +102,7 @@ Source order (`hyprland.conf:22-41`): `theme-colors.conf` (generated), then
 | `conf/workspace.conf`                         | Workspaces 1-4 pinned to `DP-1`, 5-8 to `DP-2`. Machine specific.                                                                                                                                                                   |
 | `conf/keybinding.conf`                        | `SUPER` is the modifier. `SUPER+Return` terminal, `SUPER+Space` launcher, `SUPER+C` kill, `SUPER+E` files, `SUPER+H/J/K/L` focus (mapped left/right/up/down in that order), `Home` / `Shift+Home` screenshot, `SUPER+Shift+L` lock. |
 | `conf/keyboard.conf`                          | US layout, `ctrl:nocaps`, natural scroll off.                                                                                                                                                                                       |
-| `conf/autostart.conf`                         | Runs `~/.config/hypr/scripts/xdg.sh` (**missing from this repo**), import-gsettings, Waybar launch, hypridle, `hyprshade auto`, nm-applet, hyprpaper, blueman-applet.                                                               |
+| `conf/autostart.conf`                         | Runs import-gsettings, Waybar launch, hypridle, `hyprshade auto`, nm-applet, hyprpaper, blueman-applet.                                                                                                                             |
 | `conf/theme.conf`                             | Styling only. Consumes `$bg $surface $surface_alt $fg $fg_muted $accent $accent_alt $warn $error $success` from the generated `theme-colors.conf`. Blur and shadow are off.                                                         |
 | `conf/window.conf`                            | dwindle layout, gaps 10/14, border 3. Its `general {}` block is overridden by `conf/theme.conf` because that is sourced later.                                                                                                      |
 | `conf/environment.conf`                       | Empty file.                                                                                                                                                                                                                         |
@@ -122,7 +122,7 @@ tracked here.
 **Target:** `~/.config/hyprshade`
 
 One schedule: `blue-light-filter` from 20:30 to 06:00. Started by
-`hyprland/.config/hypr/conf/autostart.conf:20` (`hyprshade auto`).
+`hyprland/.config/hypr/conf/autostart.conf:17` (`hyprshade auto`).
 
 ---
 

--- a/hyprland/.config/hypr/conf/autostart.conf
+++ b/hyprland/.config/hypr/conf/autostart.conf
@@ -4,9 +4,6 @@
 # /_/ |_\_,_/\__/\___/___/\__/\_,_/_/  \__/
 #
 
-# Setup XDG for screen sharing and start waypaper and waybar
-exec-once = ~/.config/hypr/scripts/xdg.sh
-
 # Import GSettings
 exec = sh ~/.config/scripts/import-gsettings.sh
 


### PR DESCRIPTION
Deletes the dead `xdg.sh` autostart entry and replaces the docs that described it as a gap with what screen sharing actually requires.

**Closes #45.**

## The change

`hyprland/.config/hypr/conf/autostart.conf` — removed `exec-once = ~/.config/hypr/scripts/xdg.sh` and its now-orphaned comment. The other five `exec`/`exec-once` lines are byte-identical; only their line numbers shift up by three.

## Why it is safe

The script never existed. A full `git rev-list --all` scan finds no commit on any branch containing `xdg.sh`, and the line has been present since `39c79c4` (2025-03-09) — failing silently at every login for roughly 17 months. It was never deployed either: `~/.config/hypr/scripts/` holds only `hyprpaper.sh`.

It is also redundant by design. Hyprland performs the environment export itself:

```
strings /usr/bin/Hyprland
  systemctl --user import-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE \
    XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS && \
    hash dbus-update-activation-environment 2>/dev/null && dbus-update-activation-environment --systemd …
```

That is exactly the payload a hand-rolled `xdg.sh` would carry.

## Docs

`docs/installation.md` and `docs/packages.md` both listed the missing script as a known gap — false once it is gone. Replaced with a short, accurate account of what screen sharing needs: the `xdg-desktop-portal-hyprland` backend package (without it there is no `hyprland.portal` and `org.freedesktop.portal.ScreenCast` is simply absent from the bus), plus the fact that `/usr/share/xdg-desktop-portal/hyprland-portals.conf` — shipped by the `hyprland` package — already declares `[preferred] default=hyprland;gtk`. No versions are pinned in the docs, so nothing there goes stale.

Deleting three lines also shifted every `autostart.conf:N` citation in the docs. Seven were corrected (`installation.md:106,107,109,114,115`, `packages.md:26,125`) and re-verified against the post-edit file — leaving them would have reintroduced exactly the doc-drift this PR is fixing.

## Verification

```
git grep -n "xdg.sh"                              -> no hits, repo-wide
other references to the deleted line              -> none; only hypr/scripts ref left is
                                                     keybinding.conf:16 -> hyprpaper.sh, which exists
git diff --stat origin/main..HEAD                 -> 3 files, +27/-16, no reformat hunks
git diff --name-only origin/main..HEAD -- nvim    -> empty
```

Table cells were hand-padded so every row keeps its existing fixed width — no table reflow in the diff.

## Note

This does not by itself restore screen sharing. The backend is now installed, but `xdg-desktop-portal` only scans for backends at startup, so it needs a re-login or:

```sh
systemctl --user restart xdg-desktop-portal xdg-desktop-portal-hyprland
```

Not run here — restarting portals mid-session can disrupt anything currently using one.
